### PR TITLE
Handle errors other than AssertionError too

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -1,9 +1,28 @@
+const AssertionError = require("assert").AssertionError;
+
+const formatAssertionError = ({ actual, expected, operator, name }) => {
+  const errorName = name.substring(0, name.indexOf(' '));
+
+  return description = `${errorName}: ${JSON.stringify(actual)} ${operator} ${JSON.stringify(expected)}`;
+}
+
 const execute = async (executable) => {
   try {
     await executable.apply();
-    return true;
-  } catch ({actual, expected}) {
-    return {actual, expected};
+    return { result: true };
+  } catch (error) {
+    let description;
+    
+    if (error instanceof AssertionError) {
+      description = formatAssertionError(error);
+    } else {
+      description = error;
+    }
+
+    return {
+      result: false,
+      description
+    };
   }
 };
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -2,20 +2,21 @@ const execute = require('./execute');
 const consoleReporter = require('./reporters/console-reporter');
 
 const executeUnit = async ({ description, testFunction, specs }, {reporter, executor}) => {
-  const result = await executor(testFunction);
-  const isTestPassed = result === true;
+  const spec = await executor(testFunction);
 
   if(specs.length > 0) {
-    reporter.step(`${specs.join(' ')} ${description}`, isTestPassed);
+    reporter.step(`${specs.join(' ')} ${description}`, spec.result);
   } else {
-    reporter.step(description, isTestPassed);
+    reporter.step(description, spec.result);
   }
 
-  if(!isTestPassed) {
-    reporter.log(`\tActual: ${result.actual}, Expected: ${result.expected}`);
+  if(!spec.result) {
+    reporter.newLine();
+    reporter.log(spec.description);
+    reporter.newLine();
   }
 
-  return isTestPassed;
+  return spec.result;
 };
 
 const runner = (unitCollector, dependencies) => {

--- a/tests/execute.spec.js
+++ b/tests/execute.spec.js
@@ -5,24 +5,39 @@ const { spec, unit } = require('../lib');
 spec('execute', () => {
   unit('should return true for succeeding executable', async () => {
     const succeedingExecutable = () => assert.equal(1, 1);
-    await execute(succeedingExecutable).then(res => assert(res));
+    await execute(succeedingExecutable).then(res => assert(res.result));
   });
 
-  unit('should return expected and actual values for failing executable', async () => {
-    const failingExecutable = () => assert.equal(0, 1);
-    const failureObj = {
-      expected: 1,
-      actual: 0
-    };
-    await execute(failingExecutable).then(res => assert.deepEqual(failureObj, res));
+  spec('Assertion Error', () => {
+    unit('should return expected and actual values for failing executable', async () => {
+      const failingExecutable = () => assert.equal(0, 1);
+      const failureObj = {
+        result: false,
+        description: `AssertionError: 0 == 1`
+      };
+      await execute(failingExecutable).then(res => assert.deepEqual(failureObj, res));
+    });
+  
+    unit('should be able to execute async functions', async () => {
+      const failingExecutable = () => new Promise((resolve) => resolve(assert.equal(0, 1)));
+      const failureObj = {
+        result: false,
+        description: `AssertionError: 0 == 1`
+      };
+      await execute(failingExecutable).then(res => assert.deepEqual(failureObj, res));
+    });
   });
 
-  unit('should be able to execute async functions', async () => {
-    const failingExecutable = () => new Promise((resolve) => resolve(assert.equal(0, 1)));
-    const failureObj = {
-      expected: 1,
-      actual: 0
-    };
-    await execute(failingExecutable).then(res => assert.deepEqual(failureObj, res));
+  spec('Other Errors', () => {
+    unit('should return description and stack trace', async () => {
+      const referrenceErrorExecutable = () => assert(notDefined);
+      const failureObj = {
+        result: false,
+        reason: 'ReferenceError: notDefined is not defined'
+      }
+      const actualFailureObj = await execute(referrenceErrorExecutable);
+      
+      assert.equal(failureObj.result, actualFailureObj.result);
+    });
   });
 });

--- a/tests/runner.spec.js
+++ b/tests/runner.spec.js
@@ -16,7 +16,7 @@ spec('Runner', () => {
     const unitCollector = new UnitCollector();
     const description = 'test';
     const testFunction = () => {};
-    const execute = () => true;
+    const execute = () => ({result: true});
 
     unitCollector.addUnit(description, testFunction);
 
@@ -31,7 +31,7 @@ spec('Runner', () => {
     const specDescription = 'spec';
     const unitDescription = 'unit';
     const testFunction = () => {};
-    const execute = () => true;
+    const execute = () => ({result: true});
 
     unitCollector.addSpec(specDescription, () => {
       unitCollector.addUnit(unitDescription, testFunction);
@@ -49,7 +49,7 @@ spec('Runner', () => {
     const specDescription = 'spec';
     const unitDescription = 'unit';
     const testFunction = () => {};
-    const execute = () => Promise.resolve(true);
+    const execute = () => Promise.resolve({result: true});
 
     unitCollector.addSpec(specDescription, () => {
       unitCollector.addUnit(unitDescription, testFunction);
@@ -66,7 +66,10 @@ spec('Runner', () => {
     const unitCollector = new UnitCollector();
     const specDescription = 'spec';
     const unitDescription = 'unit';
-    const failureObj = {expected: 1, actual: 0};
+    const failureObj = {
+      result: false,
+      description: 'AssertionError: 0 == 1'
+    };
     const testFunction = () => {};
     const execute = () => (failureObj);
 
@@ -76,7 +79,7 @@ spec('Runner', () => {
 
     await runner(unitCollector, { reporter, execute });
 
-    assert(reporter.log.calledWith(`\tActual: ${failureObj.actual}, Expected: ${failureObj.expected}`));
+    assert(reporter.log.calledWith(failureObj.description));
   });
 
 });


### PR DESCRIPTION
Library was not able to handle any kind of error except AssertionError.
This should not be the case for a spec runner, it should be able to
provide feedback against any kind of error
#8 