### PR TITLE
Add exit code for results of the tests

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -23,6 +23,7 @@ const runner = (unitCollector, dependencies) => {
   // TODO: Add some syntactic sugar
   const executor = (dependencies && dependencies.execute) || execute;
   const reporter = (dependencies && dependencies.reporter) || consoleReporter;
+  const processInterface = (dependencies && dependencies.process) || process;
   let unitPromises = [];
 
   unitCollector.withEachUnit(unit => {
@@ -38,6 +39,12 @@ const runner = (unitCollector, dependencies) => {
     reporter.newLine();
     reporter.result(failures, successes);
     reporter.newLine();
+
+    if (failures === 0) {
+      processInterface.exit(0);
+    } else {
+      processInterface.exit(1);
+    }
   });
 };
 


### PR DESCRIPTION
For now, it's OK to return 0 for succeeding runs and 1 for failures.
This implementation will make CI fail if any test is failed. #12